### PR TITLE
Add attribute and health end point

### DIFF
--- a/cmd/attributes/endpoints.go
+++ b/cmd/attributes/endpoints.go
@@ -1,0 +1,31 @@
+package attributes
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+type EndPoints struct {
+	GetAttributes      endpoint.Endpoint
+	ValidateAttributes endpoint.Endpoint
+}
+
+func MakeEndpoints() EndPoints {
+	return EndPoints{
+		GetAttributes:      makeAttributeEndpoint(),
+		ValidateAttributes: makeValidateAttributeEndpoint(),
+	}
+}
+
+func makeAttributeEndpoint() endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		return []string{}, nil
+	}
+}
+
+func makeValidateAttributeEndpoint() endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		return nil, nil
+	}
+}

--- a/cmd/attributes/service.go
+++ b/cmd/attributes/service.go
@@ -1,0 +1,8 @@
+package attributes
+
+type Service interface {
+	// GetAttributes returns the list of attributes for a kind. Since the compliance provider connector
+	// does not have any attributes, this function returns an empty list.
+	GetAttributes() ([]interface{}, error)
+	ValidateAttributes() ([]interface{}, error)
+}

--- a/cmd/health/endpoints.go
+++ b/cmd/health/endpoints.go
@@ -1,0 +1,24 @@
+package health
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+type EndPoints struct {
+	GetHealth endpoint.Endpoint
+}
+
+func MakeEndpoints(s Service) EndPoints {
+	return EndPoints{
+		GetHealth: makeHealthEndPoint(s),
+	}
+}
+
+func makeHealthEndPoint(s Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		healthStatus := s.GetHealth()
+		return healthStatus, nil
+	}
+}

--- a/cmd/health/health.go
+++ b/cmd/health/health.go
@@ -1,0 +1,14 @@
+package health
+
+type service struct{}
+
+func NewService() Service {
+	return &service{}
+}
+
+func (s service) GetHealth() Health {
+	return Health{
+		Status:      "ok",
+		Description: "OK",
+	}
+}

--- a/cmd/health/requestresponse.go
+++ b/cmd/health/requestresponse.go
@@ -1,0 +1,8 @@
+package health
+
+type (
+	Health struct {
+		Status      string `json:"status"`
+		Description string `json:"description"`
+	}
+)

--- a/cmd/health/service.go
+++ b/cmd/health/service.go
@@ -1,0 +1,7 @@
+package health
+
+type Service interface {
+	// GetHealth returns the health of the connector. Since the compliance provider connector
+	// does not have any real checks, it returns a healthy status.
+	GetHealth() Health
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,22 +1,39 @@
 package cmd
 
 import (
+	"CZERTAINLY-X509-Compliance-Provider/cmd/attributes"
 	"CZERTAINLY-X509-Compliance-Provider/cmd/compliance"
+	"CZERTAINLY-X509-Compliance-Provider/cmd/health"
 	"CZERTAINLY-X509-Compliance-Provider/cmd/info"
 	"CZERTAINLY-X509-Compliance-Provider/cmd/rules"
 	"CZERTAINLY-X509-Compliance-Provider/cmd/utils"
 	"context"
+	"net/http"
+
 	httptransport "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
-	"net/http"
 )
 
-func NewHttpServer(router *mux.Router, ctx context.Context, infoEndpoint info.EndPoints, complianceEndpoints compliance.EndPoints, rulesEndPoints rules.EndPoints) http.Handler {
+func NewHttpServer(router *mux.Router, ctx context.Context, infoEndpoint info.EndPoints,
+	complianceEndpoints compliance.EndPoints, rulesEndPoints rules.EndPoints,
+	attributeEndPoints attributes.EndPoints, healthEndPoint health.EndPoints) http.Handler {
 	router.Use(commonMiddleware)
 
 	router.Methods("GET").Path("/v1").Handler(httptransport.NewServer(
 		infoEndpoint.GetInfo, utils.DecodeRequest, utils.EncodeResponse,
 	)).Name("listSupportedFunctions")
+
+	router.Methods("GET").Path("/v1/complianceProvider/{kind}/attributes").Handler(httptransport.NewServer(
+		attributeEndPoints.GetAttributes, utils.DecodeRequest, utils.EncodeResponse,
+	)).Name("listAttributes")
+
+	router.Methods("POST").Path("/v1/complianceProvider/{kind}/attributes").Handler(httptransport.NewServer(
+		attributeEndPoints.ValidateAttributes, utils.DecodeRequest, utils.EncodeResponse,
+	)).Name("validateAttributes")
+
+	router.Methods("GET").Path("/v1/health").Handler(httptransport.NewServer(
+		healthEndPoint.GetHealth, utils.DecodeRequest, utils.EncodeResponse,
+	)).Name("getHealth")
 
 	router.Methods("POST").Path("/v1/complianceProvider/{kind}/compliance").Handler(httptransport.NewServer(
 		complianceEndpoints.ComplianceCheck, compliance.DecodeComplianceRequest, utils.EncodeResponse,


### PR DESCRIPTION
Add attribute and health end point to the compliance provider.

Attribute and health end point should be mandatory for all the connectors for the smooth working of the core and other components